### PR TITLE
Fix missing libraries, soundfonts, file associations, and bump to 4.3.3 

### DIFF
--- a/snap/gui/gzdoom.desktop
+++ b/snap/gui/gzdoom.desktop
@@ -6,4 +6,5 @@ Comment=The GZDoom Source Port
 Keywords=doom;gzdoom
 Type=Application
 Categories=Game;
-StartupNotify=true
+StartupNotify=false
+MimeType=application/x-doom-wad;

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -70,6 +70,7 @@ parts:
       - libslang2
       - fluid-soundfont-gm
       - libglu1-mesa
+      - freeglut3
     after:
       - desktop-glib-only
   desktop-glib-only:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: gzdoom
 base: core18
-version: 'g4.3.2'
+version: 'g4.3.3'
 summary: Doom Source Port
 description: |
   Snap build from https://github.com/Hvassaa/gzdoom-snap
@@ -28,7 +28,7 @@ apps:
 parts:
   gzdoom:
     source: https://github.com/coelckers/gzdoom.git
-    source-tag: 'g4.3.2'
+    source-tag: 'g4.3.3'
     plugin: cmake
     configflags: ["-DCMAKE_BUILD_TYPE=Release", "-DNO_FMOD=ON"]
     build-packages:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -73,6 +73,10 @@ parts:
       - freeglut3
     after:
       - desktop-glib-only
+    override-build: |
+      snapcraftctl build
+      mkdir -p $SNAPCRAFT_PART_INSTALL/usr/share/sounds/sf2
+      cp $SNAPCRAFT_PART_BUILD/soundfonts/gzdoom.sf2 $SNAPCRAFT_PART_INSTALL/usr/share/sounds/sf2/gzdoom.sf2
   desktop-glib-only:
     source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
     source-subdir: glib-only


### PR DESCRIPTION
This PR does the following:

- adds freeglut3 to the staged packages because snapcraft complains that it's missing and without it, wildmidi will not work.
- adds gzdoom soundfont to the installation so that the music is consistent with the other distributions of GZDoom
- Adds a file association with WAD files so that GZDoom can open them automatically
- Bumps the GZDoom version to 4.3.3