### PR TITLE
Tweak the snap metadata

### DIFF
--- a/snap/local/location.patch
+++ b/snap/local/location.patch
@@ -1,13 +1,18 @@
---- d_iwad.cpp	2021-07-05 16:02:48.175410473 +0200
-+++ d_iwad.cpp_modified	2021-07-05 17:13:12.378648398 +0200
-@@ -685,8 +685,8 @@
+diff --git a/src/d_iwad.cpp b/src/d_iwad.cpp
+index 4758064a3..cb612896a 100644
+--- a/src/d_iwad.cpp
++++ b/src/d_iwad.cpp
+@@ -720,9 +720,10 @@ int FIWadManager::IdentifyVersion (std::vector<std::string>&wadfiles, const char
  					  "2. Edit your ~/Library/Preferences/" GAMENAMELOWERCASE ".ini and add the directories\n"
  					  "of your iwads to the list beneath [IWADSearch.Directories]");
  #else
 -					  "1. Place one or more of these wads in ~/.config/" GAMENAMELOWERCASE "/.\n"
 -					  "2. Edit your ~/.config/" GAMENAMELOWERCASE "/" GAMENAMELOWERCASE ".ini and add the directories of your\n"
+-					  "iwads to the list beneath [IWADSearch.Directories]");
 +					  "1. Place one or more of these wads in ~/snap/gzdoom/current/.config/" GAMENAMELOWERCASE "/.\n"
 +					  "2. Edit your ~/snap/gzdoom/current/.config/" GAMENAMELOWERCASE "/" GAMENAMELOWERCASE ".ini and add the directories of your\n"
- 					  "iwads to the list beneath [IWADSearch.Directories]");
++					  "iwads to the list beneath [IWADSearch.Directories]\n\n"
++                      "NOTE: this snap does not use the home interface and thus cannot access directories outside of its own.");
  #endif
  	}
+ 	int pick = 0;

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,7 @@
 name: gzdoom
+title: GZDoom
 base: core22
-version: '4.12.2'
+adopt-info: gzdoom # version is set based on the git tag we check out
 summary: Doom Source Port
 description: |
   Snap build from https://github.com/Hvassaa/gzdoom-snap
@@ -8,8 +9,9 @@ description: |
   ZDoom is a family of enhanced ports of the Doom engine for running on modern operating systems.
   It runs on Windows, Linux, and OS X, and adds new features not found in the games as originally
   published by id Software.
-license: "GPL-3.0"
-source-code: "https://github.com/ZDoom/gzdoom"
+license: GPL-3.0
+icon: snap/gui/gzdoom.png
+source-code: "https://github.com/Hvassaa/gzdoom-snap"
 grade: stable
 confinement: strict
 
@@ -35,12 +37,13 @@ parts:
     source: https://github.com/ZDoom/gzdoom.git
     source-tag: 'g4.12.2'
     override-pull: |
-      snapcraftctl pull
+      craftctl default
+      craftctl set version=$(git describe --tags --abbrev=10 | sed 's/^g//')
       patch $SNAPCRAFT_PART_SRC/src/d_iwad.cpp < $SNAPCRAFT_PROJECT_DIR/snap/local/location.patch # change "wad not found" path description
     plugin: cmake
     cmake-parameters:
       - -DCMAKE_BUILD_TYPE=Release
-      - -DNO_FMOD=ON
+      - -DNO_FMOD=ON # only necessary for gzdoom < 3
       - -DZMUSIC_INCLUDE_DIR=$SNAPCRAFT_STAGE/usr/include
       - -DZMUSIC_LIBRARIES=$SNAPCRAFT_STAGE/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libzmusic.so
     build-packages:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: gzdoom
 base: core22
-version: '4.10.0'
+version: '4.12.2'
 summary: Doom Source Port
 description: |
   Snap build from https://github.com/Hvassaa/gzdoom-snap
@@ -32,8 +32,8 @@ layout:
 
 parts:
   gzdoom:
-    source: https://github.com/coelckers/gzdoom.git
-    source-tag: 'g4.10.0'
+    source: https://github.com/ZDoom/gzdoom.git
+    source-tag: 'g4.12.2'
     override-pull: |
       snapcraftctl pull
       patch $SNAPCRAFT_PART_SRC/src/d_iwad.cpp < $SNAPCRAFT_PROJECT_DIR/snap/local/location.patch # change "wad not found" path description
@@ -82,8 +82,8 @@ parts:
       - zmusic
       - desktop-qt5
   zmusic:
-    source: https://github.com/coelckers/ZMusic.git
-    source-tag: '1.1.12'
+    source: https://github.com/ZDoom/ZMusic.git
+    source-tag: '1.1.13'
     plugin: cmake
     cmake-parameters:
       - -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
Tweak the snap metadata

* derive snap version from GZDoom git tag
* document why we disable FMOD
* correctly set the license
* source-code should point to the snap source, not the payload source
* snapcraftctl is deprecated in favor of craftctl